### PR TITLE
Update AppServiceProvider.php

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Schema;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -13,7 +14,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Schema::defaultStringLength(191);
     }
 
     /**


### PR DESCRIPTION
the command: php artisan migrate --seed

SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 byte

the solution I found was to do the following:
Go to App\Providers\AppServiceProvider.php.
Add this to provider use Illuminate\Support\Facades\Schema; in top.
Inside the Boot function Add this Schema::defaultStringLength(191);