### PR TITLE
Added the option to forward the webhook onto something else

### DIFF
--- a/app/Http/Controllers/WebhookController.php
+++ b/app/Http/Controllers/WebhookController.php
@@ -103,7 +103,6 @@ class WebhookController extends Controller
                     'fastnet' => $request->all(),
                 ]
             ]);
-            return;
         }
 
         if($cc !== false) {

--- a/app/Http/Controllers/WebhookController.php
+++ b/app/Http/Controllers/WebhookController.php
@@ -87,22 +87,26 @@ class WebhookController extends Controller
         $cc = env('ACTION_CC', false);
         
         if (env('FORWARD_WEBHOOK')) {
-            $client = new Client();
-            $client->post(rtrim(env('FORWARD_WEBHOOK'), '/') . '/webhook', [
-                'json' => [
-                    'ui' => [
-                        'dc_id' => $dc->id,
-                        'dc_name' => $dc->name,
-                        'action_id' => $action->id,
-                        'created_at' => \Carbon\Carbon::now()->format(\DateTime::ATOM),
-                        'hostgroup_id' => $action->hostgroup_id,
-                        'hostgroup' => $action->hostgroup->name,
-                        'email_to' => $to,
-                        'email_cc' => explode(",", env('ACTION_CC', null)),
-                    ],
-                    'fastnet' => $request->all(),
-                ]
-            ]);
+            try {
+                $client = new Client();
+                $client->post(rtrim(env('FORWARD_WEBHOOK'), '/') . '/webhook', [
+                    'json' => [
+                        'ui' => [
+                            'dc_id' => $dc->id,
+                            'dc_name' => $dc->name,
+                            'action_id' => $action->id,
+                            'created_at' => \Carbon\Carbon::now()->format(\DateTime::ATOM),
+                            'hostgroup_id' => $action->hostgroup_id,
+                            'hostgroup' => $action->hostgroup->name,
+                            'email_to' => $to,
+                            'email_cc' => explode(",", env('ACTION_CC', null)),
+                        ],
+                        'fastnet' => $request->all(),
+                    ]
+                ]);
+            } catch (\Exception $e) {
+                \Log::critical("Failed to send webhook", [$e]);
+            } finally {}
         }
 
         if($cc !== false) {

--- a/app/Http/Controllers/WebhookController.php
+++ b/app/Http/Controllers/WebhookController.php
@@ -89,7 +89,7 @@ class WebhookController extends Controller
         if (env('FORWARD_WEBHOOK')) {
             try {
                 $client = new Client();
-                $client->post(rtrim(env('FORWARD_WEBHOOK'), '/') . '/webhook', [
+                $client->post(env('FORWARD_WEBHOOK'), [
                     'json' => [
                         'ui' => [
                             'dc_id' => $dc->id,


### PR DESCRIPTION
When receiving a webhook from fastnetmon, If FORWARD_WEBHOOK is set in the .env file, fnm-ui will first populate the database with the necessary data and pass the webhook on.

This means users can add in business specific logic without having to maintain their own fork