### PR TITLE
remove deprecated fields for actions

### DIFF
--- a/app/Actions.php
+++ b/app/Actions.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 class Actions extends Model
 {
     protected $fillable = [
-        'id','created_at','updated_at','hostgroup_id','ip_id','action','uuid','ip','attack_severity','attack_direction','attack_type','attack_protocol','attack_detection_source','attack_initial_power','attack_peak_power','attack_total_incoming_traffic','attack_total_outgoing_traffic','attack_total_incoming_pps','attack_total_outgoing_pps','attack_total_incoming_flows','attack_total_outgoing_flows',
+        'id','created_at','updated_at','hostgroup_id','ip_id','action','uuid','ip','attack_severity','attack_detection_threshold','attack_detection_threshold_direction','attack_detection_source','attack_total_incoming_traffic','attack_total_outgoing_traffic','attack_total_incoming_pps','attack_total_outgoing_pps','attack_total_incoming_flows','attack_total_outgoing_flows',
     ];
 
     public function range() {

--- a/app/Http/Controllers/WebhookController.php
+++ b/app/Http/Controllers/WebhookController.php
@@ -63,19 +63,16 @@ class WebhookController extends Controller
         $action->hostgroup_id = $range->hostgroup->id;
         $action->dc_id = $range->hostgroup->dc->id;
 
-        $action->attack_severity                   = $data['attack_details']['attack_severity'];
-        $action->attack_direction                  = $data['attack_details']['attack_direction'];
-        $action->attack_type                       = $data['attack_details']['attack_type'];
-        $action->attack_protocol                   = $data['attack_details']['attack_protocol'];
-        $action->attack_detection_source           = $data['attack_details']['attack_detection_source'];
-        $action->attack_initial_power              = $data['attack_details']['initial_attack_power'];
-        $action->attack_peak_power                 = $data['attack_details']['peak_attack_power'];
-        $action->attack_total_incoming_traffic     = $data['attack_details']['total_incoming_traffic'];
-        $action->attack_total_outgoing_traffic     = $data['attack_details']['total_outgoing_traffic'];
-        $action->attack_total_incoming_pps         = $data['attack_details']['total_incoming_pps'];
-        $action->attack_total_outgoing_pps         = $data['attack_details']['total_outgoing_pps'];
-        $action->attack_total_incoming_flows       = $data['attack_details']['total_incoming_flows'];
-        $action->attack_total_outgoing_flows       = $data['attack_details']['total_outgoing_flows'];
+        $action->attack_severity                        = $data['attack_details']['attack_severity'];
+        $action->attack_detection_threshold             = $data['attack_details']['attack_detection_threshold'];
+        $action->attack_detection_threshold_direction   = $data['attack_details']['attack_detection_threshold_direction'];
+        $action->attack_detection_source                = $data['attack_details']['attack_detection_source'];
+        $action->attack_total_incoming_traffic          = $data['attack_details']['total_incoming_traffic'];
+        $action->attack_total_outgoing_traffic          = $data['attack_details']['total_outgoing_traffic'];
+        $action->attack_total_incoming_pps              = $data['attack_details']['total_incoming_pps'];
+        $action->attack_total_outgoing_pps              = $data['attack_details']['total_outgoing_pps'];
+        $action->attack_total_incoming_flows            = $data['attack_details']['total_incoming_flows'];
+        $action->attack_total_outgoing_flows            = $data['attack_details']['total_outgoing_flows'];
 
         if(isset($data['packet_dump']) && !empty($data['packet_dump'])) {
             $action->packet_dump = json_encode($data['packet_dump']);

--- a/database/migrations/2026_03_19_132100_update_actions_table.php
+++ b/database/migrations/2026_03_19_132100_update_actions_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('actions', function (Blueprint $table) {
+            $table->string('attack_detection_threshold')->nullable();
+            $table->string('attack_detection_threshold_direction')->nullable();
+            $table->dropColumn(['attack_type', 'attack_direction', 'attack_protocol', 'attack_initial_power', 'attack_peak_power']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('actions', function (Blueprint $table) {
+                $table->dropColumn(['attack_detection_threshold', 'attack_detection_threshold_direction']);
+                $table->string('attack_direction')->nullable();
+                $table->string('attack_type')->nullable();
+                $table->string('attack_protocol')->nullable();
+        });
+    }
+};

--- a/resources/views/action/show.blade.php
+++ b/resources/views/action/show.blade.php
@@ -115,12 +115,12 @@ View Action - {{$action->uuid}}
                             <td>{{ strtoupper($action->attack_severity) }}</td>
                         </tr>
                         <tr>
-                            <th>Attack Type</th>
-                            <td>{{ strtoupper($action->attack_type) }}</td>
+                            <th>Attack Threshold</th>
+                            <td>{{ strtoupper($action->attack_detection_threshold) }}</td>
                         </tr>
                         <tr>
-                            <th>Attack Protocol</th>
-                            <td>{{ strtoupper($action->attack_protocol) }}</td>
+                            <th>Attack Direction</th>
+                            <td>{{ strtoupper($action->attack_detection_threshold_direction) }}</td>
                         </tr>
                         <tr>
                             <th>Detection Source</th>

--- a/resources/views/dc/show.blade.php
+++ b/resources/views/dc/show.blade.php
@@ -224,7 +224,7 @@ Manage DC - {{$dc->name}}
                             @if($i->attack_detection_source == "manual")
                                 <td>Manually {{ $i->action }}ned {{ $i->ip }}</td>
                             @else
-                                <td>{{ ucfirst($i->action) }}ned {{ $i->ip }} at {{ round($i->attack_peak_power / 1024, 2) }} kpps</td>
+                                <td>{{ ucfirst($i->action) }}ned {{ $i->ip }} ({{ $i->attack_detection_threshold }})</td>
                             @endif
                             <td class="text-right"><td class="text-right"><a href="{{ route('action.show', $i) }}" data-toggle="tooltip" data-placement="left" title="View attack details"><i class="fa fa-search-plus" aria-hidden="true"></i></a></td></td>
                         </tr>

--- a/resources/views/emails/action-received.blade.php
+++ b/resources/views/emails/action-received.blade.php
@@ -63,24 +63,12 @@ table {
         <td>{{ $action->attack_severity }}</td>
     </tr>
     <tr>
-        <td>Attack Direction:</td>
-        <td>{{ $action->attack_direction }}</td>
+        <td>Attack Detection Threshold:</td>
+        <td>{{ $action->attack_detection_threshold }}</td>
     </tr>
     <tr>
-        <td>Attack Protocol:</td>
-        <td>{{ $action->attack_protocol }}</td>
-    </tr>
-    <tr>
-        <td>Attack Type:</td>
-        <td>{{ $action->attack_type }}</td>
-    </tr>
-    <tr>
-        <td>Initial Attack Power:</td>
-        <td>{{ $action->attack_initial_power }} pps</td>
-    </tr>
-    <tr>
-        <td>Initial Peak Power:</td>
-        <td>{{ $action->attack_peak_power }} pps</td>
+        <td>Attack Detection Threshold Direction:</td>
+        <td>{{ $action->attack_detection_threshold_direction }}</td>
     </tr>
     <tr>
         <td>Incoming Traffic:</td>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -247,7 +247,7 @@
                             @if($i->attack_detection_source == "manual")
                                 <td>Manually {{ $i->action }}ned {{ $i->ip }}</td>
                             @else
-                                <td>{{ ucfirst($i->action) }}ned {{ $i->ip }} at {{ $i->attack_peak_power }} pps</td>
+                                <td>{{ ucfirst($i->action) }}ned {{ $i->ip }} ({{ $i->attack_detection_threshold }})</td>
                             @endif
                             <td class="text-right"><a href="{{ route('action.show', $i) }}" data-toggle="tooltip" data-placement="left" title="View attack details"><i class="fa fa-search-plus" aria-hidden="true"></i></a></td>
                         </tr>


### PR DESCRIPTION
Removes deprecated fields in favour of threshold fields

- https://fastnetmon.com/docs-fnm-advanced/attack_protocol-deprecation-in-version-2-0-368/
- https://fastnetmon.com/2024/11/26/fastnetmon-advanced-2-0-368/